### PR TITLE
Rebuild cleave on options change

### DIFF
--- a/src/Cleave.vue
+++ b/src/Cleave.vue
@@ -22,7 +22,7 @@ export default {
       cleave: null
     }
   },
-  
+
   methods: {
     updateValue(value) {
       this.$emit('input', value);
@@ -35,7 +35,17 @@ export default {
 
   beforeDestroy () {
     this.cleave.destroy()
-  }
+  },
+
+  watch: {
+      options: {
+          deep: true,
+          handler(val) {
+              this.cleave.destroy()
+              this.cleave = new Cleave(this.$el, val)
+          },
+      },
+  },
 
 }
 </script>


### PR DESCRIPTION
Could we add a deep watch to the options object to rebuild if the options change?

For example, if I am using this for a phone number input that is dependent on their country setting, the option object may change.