### PR TITLE
Way of passing through events

### DIFF
--- a/src/Cleave.vue
+++ b/src/Cleave.vue
@@ -1,5 +1,5 @@
 <template>
-  <input type="text" v-bind:value="value" @input="updateValue($event.target.value)" />
+  <input ref="input" type="text" v-bind:value="value" @input="updateValue($event.target.value)" />
 </template>
 
 <script>
@@ -12,6 +12,10 @@ export default {
       default: ''
     },
     options: {
+      type: Object,
+      default: () => ({})
+    },
+    events: {
       type: Object,
       default: () => ({})
     }
@@ -31,6 +35,9 @@ export default {
 
   mounted () {
     this.cleave = new Cleave(this.$el, this.options)
+    Object.keys(this.events).map((key) => {
+        this.$refs.input.addEventListener(key, this.events[key])
+    })
   },
 
   beforeDestroy () {


### PR DESCRIPTION
Hey, me again

This PR will allow you to pass event listeners through a prop object in the following format

```js
{ 
  blur() {
    console.log('on blur')
  }
}
```

I think this is a lot cleaner than passing events through as separate props 