### PR TITLE
Update Cleave to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-cleave",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Cleave component is based on cleave.js for Vue",
   "repository": "vue-bulma/cleave",
   "license": "MIT",
@@ -24,6 +24,6 @@
     "vue": ">=2"
   },
   "dependencies": {
-    "cleave.js": "^0.7.15"
+    "cleave.js": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
     "vue": ">=2"
   },
   "dependencies": {
-    "cleave.js": "^1.0.1"
+    "cleave.js": "^1.0.2"
   }
 }

--- a/src/Cleave.vue
+++ b/src/Cleave.vue
@@ -37,7 +37,7 @@ export default {
   mounted () {
     this.$el.value = this.value
     this.cleave = new Cleave(this.$el, this.options)
-    Object.keys(this.events).map((key) => {
+    Object.keys(this.events).forEach((key) => {
       this.$refs.input.addEventListener(key, this.events[key])
     })
     if (this.options.maxLength) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-cleave.js@^0.7.15:
-  version "0.7.15"
-  resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-0.7.15.tgz#f8e33a2b4d48c48c410e4978f983c85a8be32a5a"
+cleave.js@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-1.0.1.tgz#c22b7558823012b37a956a890d25b8c5befc7988"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,6 @@
 # yarn lockfile v1
 
 
-cleave.js@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-1.0.1.tgz#c22b7558823012b37a956a890d25b8c5befc7988"
+cleave.js@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/cleave.js/-/cleave.js-1.0.2.tgz#9d1fa58cd6290c5410dde8d8664aa54f65e879af"


### PR DESCRIPTION
- Updated Cleave to 1.0.2 (includes important bug fixes such as cursor jumping)
- Using forEach instead of map, since we're not returning any values