### PR TITLE
Handle external changes to value

### DIFF
--- a/src/Cleave.vue
+++ b/src/Cleave.vue
@@ -63,6 +63,10 @@ export default {
         this.cleave.destroy()
         this.cleave = new Cleave(this.$el, val)
       }
+    },
+    // watch the value to make sure external changes (not by input) are taken into account as well
+    value: function (newValue) {
+      this.cleave.setRawValue(value(newValue));
     }
   },
 


### PR DESCRIPTION
Sometimes the value of a field is initialised or calculated externally and thus filled in automatically, not by an input event. External changes of the value are now also passed to cleave to make sure they are masked properly.

#19